### PR TITLE
Update repo references and clarify Homebrew status

### DIFF
--- a/DISTRIBUTION_GUIDE.md
+++ b/DISTRIBUTION_GUIDE.md
@@ -12,7 +12,7 @@ The GPU Text Search project is **production-ready** for distribution:
 - ✅ **Complete test suite** with validation scripts
 - ✅ **MIT License** (community-friendly)
 - ✅ **GitHub-ready files** (CI/CD, issue templates, security policy)
-- ✅ **Homebrew formula** prepared
+- ✅ **Homebrew formula** in progress
 - ✅ **Examples and tutorials** for different use cases
 
 ## 🎯 **Distribution Strategy**
@@ -261,7 +261,7 @@ The GPU Text Search project is **ready for immediate distribution**:
 ### **Distribution Assets**
 - ✅ Enhanced README with installation instructions
 - ✅ GitHub Actions CI/CD pipeline
-- ✅ Homebrew formula ready for submission
+- ✅ Homebrew formula under development
 - ✅ Security policy and contributing guidelines
 - ✅ Issue templates and community docs
 - ✅ Practical examples for different use cases

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Transform your text processing workflows with **industry-leading performance**:
 
 ## 📦 **Installation**
 
-### Homebrew (Recommended)
+### Homebrew (coming soon)
 ```bash
 # Coming soon - brew install gpu-text-search
 ```
@@ -288,7 +288,7 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/yourorg/gpu-text-search.git", from: "1.0.0")
+    .package(url: "https://github.com/teenu/gpu-text-search.git", from: "1.0.0")
 ]
 ```
 

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,6 +1,7 @@
 # Homebrew Formula for GPU Text Search
 
 This directory contains the Homebrew formula for installing GPU Text Search.
+**Note:** the formula is still being finalized and is not yet available from Homebrew Core.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- update Homebrew heading and package URL in README
- note that the Homebrew formula is not yet available
- mark Homebrew formula as in progress in distribution guide

## Testing
- `swift test` *(fails: no such module 'Metal')*

------
https://chatgpt.com/codex/tasks/task_e_6852b3f2fbc8832fbf67671725297a39